### PR TITLE
Add `==` `isequal` `isapprox` for types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tensorial = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
 
 [compat]
-Tensorial = "0.12"
 ConstructionBase = "1"
+Tensorial = "0.12"
 julia = "1"
 
 [extras]

--- a/src/types.jl
+++ b/src/types.jl
@@ -93,3 +93,18 @@ function Base.similar(A::Union{TensorStress,TensorStrain}, ::Type{S}) where {S}
     T = constructorof(typeof(A))
     return T{S}(Matrix{S}(undef, size(A)))
 end
+
+# See https://discourse.julialang.org/t/how-to-compare-two-vectors-whose-elements-are-equal-but-their-types-are-not-the-same/
+for (S, T) in (
+    (:EngineeringStress, :EngineeringStrain),
+    (:TensorStress, :TensorStrain),
+    (:StiffnessTensor, :ComplianceTensor),
+    (:StiffnessMatrix, :ComplianceMatrix),
+)
+    for op in (:(==), :isequal, :isapprox)
+        @eval begin
+            Base.$op(s::$S, t::$T) = false
+            Base.$op(t::$T, s::$S) = false
+        end
+    end
+end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -1,0 +1,9 @@
+# See https://discourse.julialang.org/t/how-to-compare-two-vectors-whose-elements-are-equal-but-their-types-are-not-the-same/
+@testset "Test equality" begin
+    @test EngineeringStrain(1:6) == EngineeringStrain(1:6)
+    @test EngineeringStrain(1:6) !== EngineeringStrain(1:6)
+    @test EngineeringStrain(1:6) != EngineeringStress(1:6)  # Different types
+    @test EngineeringStrain(1:6) !== EngineeringStrain(float(1:6))
+    @test !isequal(EngineeringStrain(1:6), EngineeringStress(1:6))  # Different types
+    @test EngineeringStrain(1:6) ≉ EngineeringStress(1:6)  # Different types
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using LinearElasticityBase
 using Test
 
 @testset "LinearElasticityBase.jl" begin
-    # Write your tests here.
+    include("arithmetic.jl")
 end


### PR DESCRIPTION
See https://discourse.julialang.org/t/how-to-compare-two-vectors-whose-elements-are-equal-but-their-types-are-not-the-same/94309/2