### PR TITLE
Deprecate `SymmetricSecondOrderTensor`, which does not support `setindex!`, use `SymmetricPacked` & `MMatrix`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+SymmetricFormats = "a91e544d-b3d6-4431-ae28-0549b1291c16"
 Tensorial = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
 
 [compat]

--- a/src/types.jl
+++ b/src/types.jl
@@ -59,6 +59,8 @@ Base.getindex(A::Union{Stress,Strain,Stiffness,Compliance}, i) = getindex(parent
 
 Base.setindex!(A::Union{EngineeringStress,EngineeringStrain}, v, i) =
     setindex!(parent(A), v, i)
+# Only set diagonal terms, see https://github.com/JuliaLang/LinearAlgebra.jl/issues/7
+Base.setindex!(A::Union{TensorStress,TensorStrain}, v, i) = setindex!(parent(A), v, i)
 
 Base.parent(A::Union{Stress,Strain,Stiffness,Compliance}) = A.data
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,11 +19,11 @@ abstract type Compliance{T,N} <: AbstractArray{T,N} end
 struct TensorStress{T} <: Stress{T,2}
     data::SymmetricPacked{T,MMatrix{3,3,T,9}}
 end
-TensorStress(m::AbstractMatrix) = TensorStress(SymmetricPacked(MMatrix{3,3}(m)))
+TensorStress(data::AbstractMatrix) = TensorStress(SymmetricPacked(MMatrix{3,3}(data)))
 struct TensorStrain{T} <: Strain{T,2}
     data::SymmetricPacked{T,MMatrix{3,3,T,9}}
 end
-TensorStrain(m::AbstractMatrix) = TensorStrain(SymmetricPacked(MMatrix{3,3}(m)))
+TensorStrain(data::AbstractMatrix) = TensorStrain(SymmetricPacked(MMatrix{3,3}(data)))
 struct StiffnessTensor{T} <: Stiffness{T,4}
     data::SymmetricFourthOrderTensor{3,T}
 end
@@ -33,21 +33,22 @@ end
 struct EngineeringStress{T} <: Stress{T,1}
     data::MVector{6,T}
 end
-EngineeringStress(v::AbstractVector) = EngineeringStress(MVector{6}(v))
-EngineeringStress(data...) = EngineeringStress(MVector{6}(data...))
+EngineeringStress(data::AbstractVector) = EngineeringStress(MVector{6}(data))
+EngineeringStress(values...) = EngineeringStress(MVector{6}(values...))
 struct EngineeringStrain{T} <: Strain{T,1}
     data::MVector{6,T}
 end
-EngineeringStrain(v::AbstractVector) = EngineeringStrain(MVector{6}(v))
-EngineeringStrain(data...) = EngineeringStrain(MVector{6}(data...))
+EngineeringStrain(data::AbstractVector) = EngineeringStrain(MVector{6}(data))
+EngineeringStrain(values...) = EngineeringStrain(MVector{6}(values...))
 struct StiffnessMatrix{T} <: Stiffness{T,2}
     data::SymmetricPacked{T,MMatrix{6,6,T,36}}
 end
-StiffnessMatrix(m::AbstractMatrix) = StiffnessMatrix(SymmetricPacked(MMatrix{6,6}(m)))
+StiffnessMatrix(data::AbstractMatrix) = StiffnessMatrix(SymmetricPacked(MMatrix{6,6}(data)))
 struct ComplianceMatrix{T} <: Compliance{T,2}
     data::SymmetricPacked{T,MMatrix{6,6,T,36}}
 end
-ComplianceMatrix(m::AbstractMatrix) = ComplianceMatrix(SymmetricPacked(MMatrix{6,6}(m)))
+ComplianceMatrix(data::AbstractMatrix) =
+    ComplianceMatrix(SymmetricPacked(MMatrix{6,6}(data)))
 
 Base.size(::Union{TensorStress,TensorStrain}) = (3, 3)
 Base.size(::Union{StiffnessTensor,ComplianceTensor}) = (3, 3, 3, 3)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,7 @@
 using ConstructionBase: constructorof
-using StaticArrays: MVector
-using Tensorial: SymmetricSecondOrderTensor, SymmetricFourthOrderTensor
+using StaticArrays: MVector, MMatrix
+using SymmetricFormats: SymmetricPacked
+using Tensorial: SymmetricFourthOrderTensor
 
 export TensorStress,
     TensorStrain,
@@ -16,15 +17,13 @@ abstract type Strain{T,N} <: AbstractArray{T,N} end
 abstract type Stiffness{T,N} <: AbstractArray{T,N} end
 abstract type Compliance{T,N} <: AbstractArray{T,N} end
 struct TensorStress{T} <: Stress{T,2}
-    data::SymmetricSecondOrderTensor{3,T,6}
+    data::SymmetricPacked{T,MMatrix{3,3,T,9}}
 end
-TensorStress(m::AbstractMatrix) = TensorStress(SymmetricSecondOrderTensor{3}(m))
-TensorStress(data...) = TensorStress(SymmetricSecondOrderTensor{3}(data...))
+TensorStress(m::AbstractMatrix) = TensorStress(SymmetricPacked(MMatrix{3,3}(m)))
 struct TensorStrain{T} <: Strain{T,2}
-    data::SymmetricSecondOrderTensor{3,T,6}
+    data::SymmetricPacked{T,MMatrix{3,3,T,9}}
 end
-TensorStrain(m::AbstractMatrix) = TensorStrain(SymmetricSecondOrderTensor{3}(m))
-TensorStrain(data...) = TensorStrain(SymmetricSecondOrderTensor{3}(data...))
+TensorStrain(m::AbstractMatrix) = TensorStrain(SymmetricPacked(MMatrix{3,3}(m)))
 struct StiffnessTensor{T} <: Stiffness{T,4}
     data::SymmetricFourthOrderTensor{3,T}
 end
@@ -42,15 +41,13 @@ end
 EngineeringStrain(v::AbstractVector) = EngineeringStrain(MVector{6}(v))
 EngineeringStrain(data...) = EngineeringStrain(MVector{6}(data...))
 struct StiffnessMatrix{T} <: Stiffness{T,2}
-    data::SymmetricSecondOrderTensor{6,T,21}
+    data::SymmetricPacked{T,MMatrix{6,6,T,36}}
 end
-StiffnessMatrix(m::AbstractMatrix) = StiffnessMatrix(SymmetricSecondOrderTensor{6}(m))
-StiffnessMatrix(data...) = StiffnessMatrix(SymmetricSecondOrderTensor{6}(data...))
+StiffnessMatrix(m::AbstractMatrix) = StiffnessMatrix(SymmetricPacked(MMatrix{6,6}(m)))
 struct ComplianceMatrix{T} <: Compliance{T,2}
-    data::SymmetricSecondOrderTensor{6,T,21}
+    data::SymmetricPacked{T,MMatrix{6,6,T,36}}
 end
-ComplianceMatrix(m::AbstractMatrix) = ComplianceMatrix(SymmetricSecondOrderTensor{6}(m))
-ComplianceMatrix(data...) = ComplianceMatrix(SymmetricSecondOrderTensor{6}(data...))
+ComplianceMatrix(m::AbstractMatrix) = ComplianceMatrix(SymmetricPacked(MMatrix{6,6}(m)))
 
 Base.size(::Union{TensorStress,TensorStrain}) = (3, 3)
 Base.size(::Union{StiffnessTensor,ComplianceTensor}) = (3, 3, 3, 3)


### PR DESCRIPTION
See https://github.com/JuliaLang/LinearAlgebra.jl/issues/7