### PR TITLE
Deprecate `==`, etc., add `isequivalent` & `⩵`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -10,7 +10,8 @@ export TensorStress,
     EngineeringStrain,
     ComplianceMatrix,
     StiffnessMatrix,
-    isequivalent
+    isequivalent,
+    ⩵
 
 abstract type Stress{T,N} <: AbstractArray{T,N} end
 abstract type Strain{T,N} <: AbstractArray{T,N} end
@@ -104,3 +105,5 @@ for (S, T) in (
         isequivalent(t::$T, s::$S) = isequivalent(s, t)
     end
 end
+isequivalent(x, y) = x == y  # Fallback
+const ⩵ = isequivalent

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,7 +9,8 @@ export TensorStress,
     EngineeringStress,
     EngineeringStrain,
     ComplianceMatrix,
-    StiffnessMatrix
+    StiffnessMatrix,
+    isequivalent
 
 abstract type Stress{T,N} <: AbstractArray{T,N} end
 abstract type Strain{T,N} <: AbstractArray{T,N} end
@@ -91,17 +92,15 @@ for T in (:TensorStress, :TensorStrain)
     @eval Base.similar(A::$T, ::Type{S}) where {S} = $T(Matrix{S}(undef, size(A)))
 end
 
-# See https://discourse.julialang.org/t/how-to-compare-two-vectors-whose-elements-are-equal-but-their-types-are-not-the-same/
+# See https://discourse.julialang.org/t/how-to-compare-two-vectors-whose-elements-are-equal-but-their-types-are-not-the-same/94309/6
 for (S, T) in (
     (:EngineeringStress, :EngineeringStrain),
     (:TensorStress, :TensorStrain),
     (:StiffnessTensor, :ComplianceTensor),
     (:StiffnessMatrix, :ComplianceMatrix),
 )
-    for op in (:(==), :isequal, :isapprox)
-        @eval begin
-            Base.$op(s::$S, t::$T) = false
-            Base.$op(t::$T, s::$S) = false
-        end
+    @eval begin
+        isequivalent(s::$S, t::$T) = false
+        isequivalent(t::$T, s::$S) = isequivalent(s, t)
     end
 end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -2,8 +2,6 @@
 @testset "Test equality" begin
     @test EngineeringStrain(1:6) == EngineeringStrain(1:6)
     @test EngineeringStrain(1:6) !== EngineeringStrain(1:6)
-    @test EngineeringStrain(1:6) != EngineeringStress(1:6)  # Different types
+    @test !(EngineeringStrain(1:6) ⩵ EngineeringStress(1:6))  # Different types
     @test EngineeringStrain(1:6) !== EngineeringStrain(float(1:6))
-    @test !isequal(EngineeringStrain(1:6), EngineeringStress(1:6))  # Different types
-    @test EngineeringStrain(1:6) ≉ EngineeringStress(1:6)  # Different types
 end


### PR DESCRIPTION
See See https://discourse.julialang.org/t/how-to-compare-two-vectors-whose-elements-are-equal-but-their-types-are-not-the-same/94309/6